### PR TITLE
Fix compilation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LIBS = -lncurses -lm
 
 .PHONY: all
 all:
-	$(CC) $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -o simuino simuino.c
+	$(CC) $(CFLAGS) $(INCLUDES) $(LFLAGS) simuino.c -o simuino $(LIBS)
 	touch temp.txt error.txt servuino/serv.error copy.error
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Clone this repository: `git clone https://github.com/irgendwr/simuino.git`
 
 And enter the folder: `cd simuino`
 
-Now compile the program: `g++ -O3 -lncurses -o simuino simuino.c`
+Now compile the program: `make`
 
 And then run it: `./simuino`
 


### PR DESCRIPTION
Wrong position for `-lncurses -lm` therefore get errors such as: undefined reference wprintw, wmove ...